### PR TITLE
Fix to SavedVariables

### DIFF
--- a/ChestFarmer/ChestFarmer.lua
+++ b/ChestFarmer/ChestFarmer.lua
@@ -17,7 +17,7 @@ function ChestFarmer.onAddonLoaded(event, addonName)
 end
 
 function ChestFarmer.Initialize()
-	ChestFarmer.savedVariables = ZO_SavedVars:NewAccountWide("ChestFarmerSavedData", 1, nil, ChestFarmer.Default)	
+	ChestFarmer.savedVariables = ZO_SavedVars:NewAccountWide("ChestFarmerSavedData", 1, nil, ChestFarmer.Default, GetWorldName())	
 	ChestFarmer.RestorePosition()
 end
 


### PR DESCRIPTION
Added GetWorldName() to SavedVars definition (thanks Baertram). To migrate old chest count go to /Documents/Elder Scrolls Online/live/SavedVariables/Chestfarmer.lua and copy-paste old values to the new table