### PR TITLE
v1.13 Update

### DIFF
--- a/ChestFarmer/ChestFarmer.lua
+++ b/ChestFarmer/ChestFarmer.lua
@@ -540,7 +540,6 @@ function ChestFarmer.interactionLog()
 		local action, name, _, isOwned = GetGameCameraInteractableActionInfo()
 		ChestFarmer.wasLastInteractableOwned = isOwned
 		ChestFarmer.lastInteractableAction = action
-		ChestFarmer.lastInteractableName = name
 		return oldInteract(...)
 	end
 end
@@ -564,7 +563,6 @@ function ChestFarmer.countIncrement()
 		end
 	else
 		if (not ChestFarmer.wasLastInteractableOwned) and ChestFarmer.lastInteractableAction == GetString(SI_GAMECAMERAACTIONTYPE12) then
-			d("last interactable name" .. ChestFarmer.lastInteractableName)
 			ChestFarmer.numChests = ChestFarmer.numChests + 1
 				if ChestFarmer.lockQuality == 4 then
 					ChestFarmer.savedVariables.masterCount = ChestFarmer.savedVariables.masterCount + 1

--- a/ChestFarmer/ChestFarmer.lua
+++ b/ChestFarmer/ChestFarmer.lua
@@ -5,6 +5,53 @@ ChestFarmer.name = "ChestFarmer"
 ChestFarmer.versionNum = 1
 ChestFarmer.numChests = 0
 ChestFarmer.numLockpicks = 0
+--Defaults
+ChestFarmer.Default = {
+guiHidden = false,
+top = 768,
+left = 1650,
+starterTC = 0,
+deshaanTC = 0, 
+eastmarchTC = 0, 
+shadowfenTC = 0, 
+stonefallsTC = 0, 
+theriftTC = 0, 
+alikrdesertTC = 0, 
+bangkoraiTC = 0, 
+glenumbraTC = 0, 
+rivenspireTC = 0, 
+stormhavenTC = 0, 
+auridonTC = 0, 
+grahtwoodTC = 0, 
+greenshadeTC = 0, 
+malabaltorTC = 0, 
+reapersmarchTC = 0, 
+summersetTC = 0, 
+wSkyrimTC = 0, 
+clockworkTC = 0, 
+coldharbourTC = 0, 
+craglornTC = 0, 
+goldcoastTC = 0, 
+hewsbaneTC = 0, 
+murkmireTC = 0, 
+nElsweyrTC = 0, 
+sElsweyrTC = 0, 
+thereachTC = 0, 
+vvardenfellTC = 0, 
+wrothgarTC = 0, 
+blackwoodTC = 0, 
+cyrodiilTC = 0, 
+impcityTC = 0,
+}
+
+
+--localized search terms for scanning chest difficulty
+ChestFarmer.enDifficulty = {"master", "advanced", "intermediate", "simple"}
+ChestFarmer.deDifficulty = {"master", "advanced", "intermediate", "simple"}
+ChestFarmer.frDifficulty = {"master", "advanced", "intermediate", "simple"}
+ChestFarmer.jpDifficulty = {"master", "advanced", "intermediate", "simple"}
+ChestFarmer.ruDifficulty = {"master", "advanced", "intermediate", "simple"}
+
 ChestFarmer.delvePd = {[124] = true, [134] = true, [137] = true, [138] = true, [142] = true, [162] = true, [169] = true, [216] = true, [270] = true, [271] = true, [272] = true, [273] = true, [274] = true, [275] = true, [284] = true, [287] = true, [288] = true, [289] = true, [290] = true, [291] = true, [296] = true, [306] = true, [308] = true, [309] = true, [310] = true, [311] = true, [312] = true, [313] = true, [314] = true, [315] = true, [316] = true, [317] = true, [318] = true, [319] = true, [320] = true, [321] = true, [322] = true, [323] = true, [324] = true, [325] = true, [326] = true, [327] = true, [328] = true, [329] = true, [330] = true, [331] = true, [332] = true, [333] = true, [334] = true, [335] = true, [336] = true, [337] = true, [338] = true, [339] = true, [341] = true, [359] = true, [360] = true, [361] = true, [362] = true, [363] = true, [364] = true, [396] = true, [397] = true, [398] = true, [399] = true, [400] = true, [401] = true, [405] = true, [406] = true, [407] = true, [408] = true, [409] = true, [410] = true, [413] = true, [417] = true, [418] = true, [419] = true, [420] = true, [421] = true, [422] = true, [442] = true, [444] = true, [447] = true, [462] = true, [463] = true, [464] = true, [465] = true, [466] = true, [467] = true, [468] = true, [469] = true, [470] = true, [471] = true, [472] = true, [473] = true, [475] = true, [477] = true, [478] = true, [480] = true, [481] = true, [482] = true, [484] = true, [485] = true, [486] = true, [487] = true, [493] = true, [494] = true, [495] = true, [496] = true, [497] = true, [498] = true, [499] = true, [500] = true, [501] = true, [502] = true, [503] = true, [504] = true, [505] = true, [506] = true, [507] = true, [531] = true, [532] = true, [557] = true, [575] = true, [576] = true, [577] = true, [578] = true, [579] = true, [580] = true, [676] = true, [689] = true, [691] = true, [692] = true, [693] = true, [694] = true, [697] = true, [705] = true, [706] = true, [817] = true, [824] = true, [825] = true, [889] = true, [890] = true, [891] = true, [892] = true, [893] = true, [894] = true, [895] = true, [896] = true, [897] = true, [898] = true, [899] = true, [900] = true, [901] = true, [902] = true, [903] = true, [904] = true, [905] = true, [906] = true, [918] = true, [919] = true, [921] = true, [922] = true, [923] = true, [924] = true, [925] = true, [961] = true, [985] = true, [986] = true, [1014] = true, [1015] = true, [1016] = true, [1017] = true, [1018] = true, [1019] = true, [1020] = true, [1021] = true, [1066] = true, [1073] = true, [1089] = true, [1090] = true, [1091] = true, [1092] = true, [1094] = true, [1095] = true, [1096] = true, [1119] = true, [1134] = true, [1135] = true, [1165] = true, [1166] = true, [1167] = true, [1168] = true, [1169] = true, [1170] = true, [1186] = true, [1187] = true, [1209] = true, [1210] = true, [1253] = true, [1257] = true, [1256] = true, [1254] = true, [1255] = true, [1258] = true, [1259] = true, [1260] = true, [1272] = true}
 
 --Init functions
@@ -23,11 +70,6 @@ end
 
 function ChestFarmer.SetScene()
 	fragment = ZO_HUDFadeSceneFragment:New(ChestFarmerWindow, nil, 0)
-	
-	--first run edgecase
-	if ChestFarmer.savedVariables.guiHidden == nil then
-		ChestFarmer.savedVariables.guiHidden = false
-	end
 	
 	if ChestFarmer.savedVariables.guiHidden == false then
 		HUD_SCENE:AddFragment(fragment)
@@ -57,8 +99,33 @@ function ChestFarmer.resetButtonPressed()
 	ChestFarmerWindowChestsCount:SetText(ChestFarmer.numChests .. " chests opened") 
 end
 
+function ChestFarmer.statsButtonPressed()
+	totalTC = 0
+	sampleSize = ChestFarmer.savedVariables.masterCount + ChestFarmer.savedVariables.advancedCount + ChestFarmer.savedVariables.intermediateCount + ChestFarmer.savedVariables.simpleCount
+		for k,v in pairs{ChestFarmer.savedVariables.starterTC, ChestFarmer.savedVariables.deshaanTC, ChestFarmer.savedVariables.eastmarchTC, ChestFarmer.savedVariables.shadowfenTC, ChestFarmer.savedVariables.stonefallsTC, ChestFarmer.savedVariables.theriftTC, ChestFarmer.savedVariables.alikrdesertTC, ChestFarmer.savedVariables.bangkoraiTC, ChestFarmer.savedVariables.glenumbraTC, ChestFarmer.savedVariables.rivenspireTC, ChestFarmer.savedVariables.stormhavenTC, ChestFarmer.savedVariables.auridonTC, ChestFarmer.savedVariables.grahtwoodTC, ChestFarmer.savedVariables.greenshadeTC, ChestFarmer.savedVariables.malabaltorTC, ChestFarmer.savedVariables.reapersmarchTC, ChestFarmer.savedVariables.summersetTC, ChestFarmer.savedVariables.wSkyrimTC, ChestFarmer.savedVariables.clockworkTC, ChestFarmer.savedVariables.coldharbourTC, ChestFarmer.savedVariables.craglornTC, ChestFarmer.savedVariables.goldcoastTC, ChestFarmer.savedVariables.hewsbaneTC, ChestFarmer.savedVariables.murkmireTC, ChestFarmer.savedVariables.nElsweyrTC, ChestFarmer.savedVariables.sElsweyrTC, ChestFarmer.savedVariables.thereachTC, ChestFarmer.savedVariables.vvardenfellTC, ChestFarmer.savedVariables.wrothgarTC, ChestFarmer.savedVariables.blackwoodTC, ChestFarmer.savedVariables.cyrodiilTC, ChestFarmer.savedVariables.impcityTC} do
+			if v ~= nil then
+				totalTC = totalTC + v
+			end
+		end
+		CHAT_ROUTER:AddSystemMessage("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+		CHAT_ROUTER:AddSystemMessage("          CHESTFARMER STATS          ")
+		CHAT_ROUTER:AddSystemMessage("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+		CHAT_ROUTER:AddSystemMessage("Total chests opened, in all zones: " .. totalTC)
+		CHAT_ROUTER:AddSystemMessage("Average chest difficulty: (Sample size " .. sampleSize .. ")")
+		CHAT_ROUTER:AddSystemMessage("Master: " .. string.format("%.2f",(ChestFarmer.savedVariables.masterCount/sampleSize)*100) .. "%")
+		CHAT_ROUTER:AddSystemMessage("Advanced: " .. string.format("%.2f",(ChestFarmer.savedVariables.advancedCount/sampleSize)*100) .. "%")
+		CHAT_ROUTER:AddSystemMessage("Intermediate: " .. string.format("%.2f",(ChestFarmer.savedVariables.intermediateCount/sampleSize)*100) .. "%")
+		CHAT_ROUTER:AddSystemMessage("Simple: " .. string.format("%.2f",(ChestFarmer.savedVariables.simpleCount/sampleSize)*100) .. "%")
+		CHAT_ROUTER:AddSystemMessage("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+end
+
 function ChestFarmer.openCollections()
 	SCENE_MANAGER:Toggle("itemSetsBook")
+end
+
+function ChestFarmer.showStats_showTooltip(self)
+	InitializeTooltip(InformationTooltip, self, TOPRIGHT, 0, 5, BOTTOMRIGHT)
+	SetTooltipText(InformationTooltip, "Print historical stats to chat")
 end
 
 function ChestFarmer.chestsReset_showTooltip(self)
@@ -88,6 +155,8 @@ function ChestFarmer.hideTooltip(self)
 end
 
 function ChestFarmer.slashHandler(param)
+	param = param:lower()
+	--toggle GUI
 	if param == "" then
 		ChestFarmer.savedVariables.guiHidden = not ChestFarmer.savedVariables.guiHidden
 		if ChestFarmer.savedVariables.guiHidden == false then
@@ -99,14 +168,10 @@ function ChestFarmer.slashHandler(param)
 			HUD_SCENE:RemoveFragment(fragment)
 			HUD_UI_SCENE:RemoveFragment(fragment)
 		end
-	elseif param == "total" then
-		totalTC = 0
-		for k,v in pairs{ChestFarmer.savedVariables.starterTC, ChestFarmer.savedVariables.deshaanTC, ChestFarmer.savedVariables.eastmarchTC, ChestFarmer.savedVariables.shadowfenTC, ChestFarmer.savedVariables.stonefallsTC, ChestFarmer.savedVariables.theriftTC, ChestFarmer.savedVariables.alikrdesertTC, ChestFarmer.savedVariables.bangkoraiTC, ChestFarmer.savedVariables.glenumbraTC, ChestFarmer.savedVariables.rivenspireTC, ChestFarmer.savedVariables.stormhavenTC, ChestFarmer.savedVariables.auridonTC, ChestFarmer.savedVariables.grahtwoodTC, ChestFarmer.savedVariables.greenshadeTC, ChestFarmer.savedVariables.malabaltorTC, ChestFarmer.savedVariables.reapersmarchTC, ChestFarmer.savedVariables.summersetTC, ChestFarmer.savedVariables.wSkyrimTC, ChestFarmer.savedVariables.clockworkTC, ChestFarmer.savedVariables.coldharbourTC, ChestFarmer.savedVariables.craglornTC, ChestFarmer.savedVariables.goldcoastTC, ChestFarmer.savedVariables.hewsbaneTC, ChestFarmer.savedVariables.murkmireTC, ChestFarmer.savedVariables.nElsweyrTC, ChestFarmer.savedVariables.sElsweyrTC, ChestFarmer.savedVariables.thereachTC, ChestFarmer.savedVariables.vvardenfellTC, ChestFarmer.savedVariables.wrothgarTC, ChestFarmer.savedVariables.blackwoodTC, ChestFarmer.savedVariables.cyrodiilTC, ChestFarmer.savedVariables.impcityTC} do
-			if v ~= nil then
-				totalTC = totalTC + v
-			end
-		end
-		CHAT_ROUTER:AddSystemMessage("Total chests opened, in all zones: " .. totalTC)
+	--stats
+	elseif param == "stats" then
+		ChestFarmer.statsButtonPressed()
+	--reset
 	elseif param == "reset" then
 		ChestFarmer.resetButtonPressed()
 	end
@@ -133,6 +198,20 @@ function ChestFarmer.fixCollected()
 end
 
 function ChestFarmer.cfRead()
+	--load correct searchterm
+	ChestFarmer.gameLang = GetCVar("Language.2")
+	if ChestFarmer.gameLang == "en" then
+		ChestFarmer.searchTerms = ChestFarmer.enDifficulty
+	elseif ChestFarmer.gameLang == "de" then
+		ChestFarmer.searchTerms = ChestFarmer.deDifficulty
+	elseif ChestFarmer.gameLang == "fr" then
+		ChestFarmer.searchTerms = ChestFarmer.frDifficulty
+	elseif ChestFarmer.gameLang == "jp" then
+		ChestFarmer.searchTerms = ChestFarmer.jpDifficulty
+	elseif ChestFarmer.gameLang == "ru" then
+		ChestFarmer.searchTerms = ChestFarmer.ruDifficulty	
+	end
+	
 	ChestFarmer.cfReadZone = {
 	--Starter Zones
 	--Bal Foyen 
@@ -447,6 +526,7 @@ function ChestFarmer.interactionLog()
 		local action, name, _, isOwned = GetGameCameraInteractableActionInfo()
 		ChestFarmer.wasLastInteractableOwned = isOwned
 		ChestFarmer.lastInteractableAction = action
+		ChestFarmer.lastInteractableName = name
 		return oldInteract(...)
 	end
 end
@@ -456,12 +536,31 @@ function ChestFarmer.countIncrement()
 		local tempSubZoneId = GetZoneId(GetUnitZoneIndex("player"))
 		if ChestFarmer.delvePd[tempSubZoneId] == true then
 			if (not ChestFarmer.wasLastInteractableOwned) and ChestFarmer.lastInteractableAction == GetString(SI_GAMECAMERAACTIONTYPE12) then
-					ChestFarmer.numChests = ChestFarmer.numChests + 1
+				ChestFarmer.numChests = ChestFarmer.numChests + 1
+					if(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[1]) then
+						ChestFarmer.savedVariables.masterCount = ChestFarmer.savedVariables.masterCount + 1
+					elseif(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[2]) then
+						ChestFarmer.savedVariables.advancedCount = ChestFarmer.savedVariables.advancedCount + 1
+					elseif(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[3]) then
+						ChestFarmer.savedVariables.intermediateCount = ChestFarmer.savedVariables.intermediateCount + 1
+					elseif(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[4]) then
+						ChestFarmer.savedVariables.simpleCount = ChestFarmer.savedVariables.simpleCount + 1
+					end
 			end
 		end
 	else
 		if (not ChestFarmer.wasLastInteractableOwned) and ChestFarmer.lastInteractableAction == GetString(SI_GAMECAMERAACTIONTYPE12) then
 			ChestFarmer.numChests = ChestFarmer.numChests + 1
+				if(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[1]) then
+					ChestFarmer.savedVariables.masterCount = ChestFarmer.savedVariables.masterCount + 1
+				elseif(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[2]) then
+					ChestFarmer.savedVariables.advancedCount = ChestFarmer.savedVariables.advancedCount + 1
+				elseif(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[3]) then
+					ChestFarmer.savedVariables.intermediateCount = ChestFarmer.savedVariables.intermediateCount + 1
+				elseif(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[4]) then
+					ChestFarmer.savedVariables.simpleCount = ChestFarmer.savedVariables.simpleCount + 1
+				end
+			end
 		end
 	end
 	ChestFarmer.cfWrite(ChestFarmer.numChests)
@@ -481,6 +580,7 @@ EVENT_MANAGER:RegisterForUpdate("ChestFarmer-InteractionLog", 800, ChestFarmer.i
 
 --Slash commands
 SLASH_COMMANDS["/chestfarmer"] = ChestFarmer.slashHandler
+SLASH_COMMANDS["/cf"] = ChestFarmer.slashHandler
 --"/chestfarmer" toggles GUI
 --"/chestfarmer total" returns total chests opened across all zones
 --"/chestfarmer reset" resets chests opened count for current zone

--- a/ChestFarmer/ChestFarmer.lua
+++ b/ChestFarmer/ChestFarmer.lua
@@ -1,3 +1,28 @@
+-------------------------------------------------------------------------------------------------------------------------------------------------
+-- Update instructions
+-------------------------------------------------------------------------------------------------------------------------------------------------
+-- To update this AddOn manually (when a new zone is released) do the following:
+-- 1. Add variable <zone_name>TC = 0 to ChestFarmer.Default for defaulting savedVariables
+-- 2. Check LibSets to get ParentZoneId and overland setIds for the zone's sets. 
+-- 2.1 Check if any delve, public dungeon or house has a different parentZoneId
+-- 2.2 Add an entry to the table in ChestFarmer.cfReadZone() in the following format:
+----- --"Zone-Name" as comment
+----- [parentZoneId] = {actual_parentZoneId, ChestFarmer.savedVariables.<zone_name>TC, {setId1, setId2, setId3 etc.}}
+--------------------------------------------------------------------------------------- ^ these setIds are the ones for the zone's overland sets.
+----- if step 2.1 is true, then add the house/quest area as a separate [parentZoneId] with the actual values
+----- To understand this, check Linchal Grand Manor for example, although it is situated in the Gold Coast, it has its own parentZoneId.
+----- For our purposes we need to load the parentZoneId for Gold Coast and the associated TC from savedVariables and the correct setIds.
+-- 3. Add an entry to ChestFarmer.cfWrite() in the following format:
+-- 	  elseif tempParentZoneId == (parentZoneId for the zone you got from libSets) then
+--    ChestFarmer.savedVariables.<zone_name>TC = tempTc
+--    No need to include houses here (if their parentZoneId is different) as this function is only called after a lockpick success event.
+-- 4. Add the zoneId of every delve and public dungeon in the zone (zoneId, not parentZoneId!)
+--    to the table in ChestFarmer.delvePd in the following format; [<zoneId>] = true, ...
+
+-----------------------
+-- ChestFarmer
+-----------------------
+
 --Variables
 
 ChestFarmer = {}

--- a/ChestFarmer/ChestFarmer.lua
+++ b/ChestFarmer/ChestFarmer.lua
@@ -33,7 +33,7 @@ ChestFarmer.numLockpicks = 0
 --Defaults
 ChestFarmer.Default = {
 guiHidden = false,
-top = 768,
+top = 614,
 left = 1650,
 starterTC = 0,
 deshaanTC = 0, 
@@ -138,7 +138,6 @@ function ChestFarmer.statsButtonPressed()
 			CHAT_ROUTER:AddSystemMessage("Advanced: " .. string.format("%.2f",(ChestFarmer.savedVariables.advancedCount/sampleSize)*100) .. "%")
 			CHAT_ROUTER:AddSystemMessage("Intermediate: " .. string.format("%.2f",(ChestFarmer.savedVariables.intermediateCount/sampleSize)*100) .. "%")
 			CHAT_ROUTER:AddSystemMessage("Simple: " .. string.format("%.2f",(ChestFarmer.savedVariables.simpleCount/sampleSize)*100) .. "%")
-			CHAT_ROUTER:AddSystemMessage("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
 		else 
 			CHAT_ROUTER:AddSystemMessage("Open more chests to populate the sample size!")
 		end
@@ -172,7 +171,7 @@ end
 
 function ChestFarmer.closeButton_showTooltip(self)
 	InitializeTooltip(InformationTooltip, self, TOPRIGHT, 0, 5, BOTTOMRIGHT)
-	SetTooltipText(InformationTooltip, "Close GUI and run in the background.\n(Use command '/chestfarmer' to toggle GUI)")
+	SetTooltipText(InformationTooltip, "Close GUI and run in the background.\n(Use command '/chestfarmer' or '/cf' to toggle GUI)")
 end
 
 function ChestFarmer.hideTooltip(self)
@@ -598,6 +597,6 @@ EVENT_MANAGER:RegisterForUpdate("ChestFarmer-InteractionLog", 800, ChestFarmer.i
 --Slash commands
 SLASH_COMMANDS["/chestfarmer"] = ChestFarmer.slashHandler
 SLASH_COMMANDS["/cf"] = ChestFarmer.slashHandler
---"/chestfarmer" toggles GUI
---"/chestfarmer total" returns total chests opened across all zones
---"/chestfarmer reset" resets chests opened count for current zone
+--"/chestfarmer" or "/cf" toggles GUI
+--"/chestfarmer ststs" or "/cf ststs" prints stats to chat
+--"/chestfarmer reset" or "/cf reset" resets chests opened count for current zone

--- a/ChestFarmer/ChestFarmer.lua
+++ b/ChestFarmer/ChestFarmer.lua
@@ -42,15 +42,11 @@ wrothgarTC = 0,
 blackwoodTC = 0, 
 cyrodiilTC = 0, 
 impcityTC = 0,
+masterCount = 0,
+advancedCount = 0,
+intermediateCount = 0,
+simpleCount = 0,
 }
-
-
---localized search terms for scanning chest difficulty
-ChestFarmer.enDifficulty = {"master", "advanced", "intermediate", "simple"}
-ChestFarmer.deDifficulty = {"master", "advanced", "intermediate", "simple"}
-ChestFarmer.frDifficulty = {"master", "advanced", "intermediate", "simple"}
-ChestFarmer.jpDifficulty = {"master", "advanced", "intermediate", "simple"}
-ChestFarmer.ruDifficulty = {"master", "advanced", "intermediate", "simple"}
 
 ChestFarmer.delvePd = {[124] = true, [134] = true, [137] = true, [138] = true, [142] = true, [162] = true, [169] = true, [216] = true, [270] = true, [271] = true, [272] = true, [273] = true, [274] = true, [275] = true, [284] = true, [287] = true, [288] = true, [289] = true, [290] = true, [291] = true, [296] = true, [306] = true, [308] = true, [309] = true, [310] = true, [311] = true, [312] = true, [313] = true, [314] = true, [315] = true, [316] = true, [317] = true, [318] = true, [319] = true, [320] = true, [321] = true, [322] = true, [323] = true, [324] = true, [325] = true, [326] = true, [327] = true, [328] = true, [329] = true, [330] = true, [331] = true, [332] = true, [333] = true, [334] = true, [335] = true, [336] = true, [337] = true, [338] = true, [339] = true, [341] = true, [359] = true, [360] = true, [361] = true, [362] = true, [363] = true, [364] = true, [396] = true, [397] = true, [398] = true, [399] = true, [400] = true, [401] = true, [405] = true, [406] = true, [407] = true, [408] = true, [409] = true, [410] = true, [413] = true, [417] = true, [418] = true, [419] = true, [420] = true, [421] = true, [422] = true, [442] = true, [444] = true, [447] = true, [462] = true, [463] = true, [464] = true, [465] = true, [466] = true, [467] = true, [468] = true, [469] = true, [470] = true, [471] = true, [472] = true, [473] = true, [475] = true, [477] = true, [478] = true, [480] = true, [481] = true, [482] = true, [484] = true, [485] = true, [486] = true, [487] = true, [493] = true, [494] = true, [495] = true, [496] = true, [497] = true, [498] = true, [499] = true, [500] = true, [501] = true, [502] = true, [503] = true, [504] = true, [505] = true, [506] = true, [507] = true, [531] = true, [532] = true, [557] = true, [575] = true, [576] = true, [577] = true, [578] = true, [579] = true, [580] = true, [676] = true, [689] = true, [691] = true, [692] = true, [693] = true, [694] = true, [697] = true, [705] = true, [706] = true, [817] = true, [824] = true, [825] = true, [889] = true, [890] = true, [891] = true, [892] = true, [893] = true, [894] = true, [895] = true, [896] = true, [897] = true, [898] = true, [899] = true, [900] = true, [901] = true, [902] = true, [903] = true, [904] = true, [905] = true, [906] = true, [918] = true, [919] = true, [921] = true, [922] = true, [923] = true, [924] = true, [925] = true, [961] = true, [985] = true, [986] = true, [1014] = true, [1015] = true, [1016] = true, [1017] = true, [1018] = true, [1019] = true, [1020] = true, [1021] = true, [1066] = true, [1073] = true, [1089] = true, [1090] = true, [1091] = true, [1092] = true, [1094] = true, [1095] = true, [1096] = true, [1119] = true, [1134] = true, [1135] = true, [1165] = true, [1166] = true, [1167] = true, [1168] = true, [1169] = true, [1170] = true, [1186] = true, [1187] = true, [1209] = true, [1210] = true, [1253] = true, [1257] = true, [1256] = true, [1254] = true, [1255] = true, [1258] = true, [1259] = true, [1260] = true, [1272] = true}
 
@@ -108,15 +104,19 @@ function ChestFarmer.statsButtonPressed()
 			end
 		end
 		CHAT_ROUTER:AddSystemMessage("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-		CHAT_ROUTER:AddSystemMessage("          CHESTFARMER STATS          ")
+		CHAT_ROUTER:AddSystemMessage("                 CHESTFARMER STATS")
 		CHAT_ROUTER:AddSystemMessage("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
 		CHAT_ROUTER:AddSystemMessage("Total chests opened, in all zones: " .. totalTC)
-		CHAT_ROUTER:AddSystemMessage("Average chest difficulty: (Sample size " .. sampleSize .. ")")
-		CHAT_ROUTER:AddSystemMessage("Master: " .. string.format("%.2f",(ChestFarmer.savedVariables.masterCount/sampleSize)*100) .. "%")
-		CHAT_ROUTER:AddSystemMessage("Advanced: " .. string.format("%.2f",(ChestFarmer.savedVariables.advancedCount/sampleSize)*100) .. "%")
-		CHAT_ROUTER:AddSystemMessage("Intermediate: " .. string.format("%.2f",(ChestFarmer.savedVariables.intermediateCount/sampleSize)*100) .. "%")
-		CHAT_ROUTER:AddSystemMessage("Simple: " .. string.format("%.2f",(ChestFarmer.savedVariables.simpleCount/sampleSize)*100) .. "%")
-		CHAT_ROUTER:AddSystemMessage("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+		CHAT_ROUTER:AddSystemMessage("Average chest quality: (Sample size " .. sampleSize .. ")")
+		if sampleSize ~= 0 then
+			CHAT_ROUTER:AddSystemMessage("Master: " .. string.format("%.2f",(ChestFarmer.savedVariables.masterCount/sampleSize)*100) .. "%")
+			CHAT_ROUTER:AddSystemMessage("Advanced: " .. string.format("%.2f",(ChestFarmer.savedVariables.advancedCount/sampleSize)*100) .. "%")
+			CHAT_ROUTER:AddSystemMessage("Intermediate: " .. string.format("%.2f",(ChestFarmer.savedVariables.intermediateCount/sampleSize)*100) .. "%")
+			CHAT_ROUTER:AddSystemMessage("Simple: " .. string.format("%.2f",(ChestFarmer.savedVariables.simpleCount/sampleSize)*100) .. "%")
+			CHAT_ROUTER:AddSystemMessage("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+		else 
+			CHAT_ROUTER:AddSystemMessage("Open more chests to populate the sample size!")
+		end
 end
 
 function ChestFarmer.openCollections()
@@ -179,6 +179,10 @@ end
 
 --Data functions
 
+function ChestFarmer.saveQuality()
+	ChestFarmer.lockQuality = GetLockQuality()
+end
+
 function ChestFarmer.fixCollected()
 	if collectedSets == 0 then
 		for k,v in pairs(zoneSets) do
@@ -198,20 +202,6 @@ function ChestFarmer.fixCollected()
 end
 
 function ChestFarmer.cfRead()
-	--load correct searchterm
-	ChestFarmer.gameLang = GetCVar("Language.2")
-	if ChestFarmer.gameLang == "en" then
-		ChestFarmer.searchTerms = ChestFarmer.enDifficulty
-	elseif ChestFarmer.gameLang == "de" then
-		ChestFarmer.searchTerms = ChestFarmer.deDifficulty
-	elseif ChestFarmer.gameLang == "fr" then
-		ChestFarmer.searchTerms = ChestFarmer.frDifficulty
-	elseif ChestFarmer.gameLang == "jp" then
-		ChestFarmer.searchTerms = ChestFarmer.jpDifficulty
-	elseif ChestFarmer.gameLang == "ru" then
-		ChestFarmer.searchTerms = ChestFarmer.ruDifficulty	
-	end
-	
 	ChestFarmer.cfReadZone = {
 	--Starter Zones
 	--Bal Foyen 
@@ -537,32 +527,33 @@ function ChestFarmer.countIncrement()
 		if ChestFarmer.delvePd[tempSubZoneId] == true then
 			if (not ChestFarmer.wasLastInteractableOwned) and ChestFarmer.lastInteractableAction == GetString(SI_GAMECAMERAACTIONTYPE12) then
 				ChestFarmer.numChests = ChestFarmer.numChests + 1
-					if(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[1]) then
+					if ChestFarmer.lockQuality == 4 then
 						ChestFarmer.savedVariables.masterCount = ChestFarmer.savedVariables.masterCount + 1
-					elseif(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[2]) then
+					elseif ChestFarmer.lockQuality == 3 then
 						ChestFarmer.savedVariables.advancedCount = ChestFarmer.savedVariables.advancedCount + 1
-					elseif(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[3]) then
+					elseif ChestFarmer.lockQuality == 2 then
 						ChestFarmer.savedVariables.intermediateCount = ChestFarmer.savedVariables.intermediateCount + 1
-					elseif(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[4]) then
+					elseif ChestFarmer.lockQuality == 1 then
 						ChestFarmer.savedVariables.simpleCount = ChestFarmer.savedVariables.simpleCount + 1
 					end
 			end
 		end
 	else
 		if (not ChestFarmer.wasLastInteractableOwned) and ChestFarmer.lastInteractableAction == GetString(SI_GAMECAMERAACTIONTYPE12) then
+			d("last interactable name" .. ChestFarmer.lastInteractableName)
 			ChestFarmer.numChests = ChestFarmer.numChests + 1
-				if(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[1]) then
+				if ChestFarmer.lockQuality == 4 then
 					ChestFarmer.savedVariables.masterCount = ChestFarmer.savedVariables.masterCount + 1
-				elseif(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[2]) then
+				elseif ChestFarmer.lockQuality == 3 then
 					ChestFarmer.savedVariables.advancedCount = ChestFarmer.savedVariables.advancedCount + 1
-				elseif(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[3]) then
+				elseif ChestFarmer.lockQuality == 2 then
 					ChestFarmer.savedVariables.intermediateCount = ChestFarmer.savedVariables.intermediateCount + 1
-				elseif(zo_plainstrfind(ChestFarmer.lastInteractableName:lower(), ChestFarmer.searchTerms[4]) then
-					ChestFarmer.savedVariables.simpleCount = ChestFarmer.savedVariables.simpleCount + 1
+				elseif ChestFarmer.lockQuality == 1 then
+						ChestFarmer.savedVariables.simpleCount = ChestFarmer.savedVariables.simpleCount + 1
 				end
-			end
 		end
 	end
+
 	ChestFarmer.cfWrite(ChestFarmer.numChests)
 	ChestFarmer.numLockpicks = GetNumLockpicksLeft("player")
 	ChestFarmerWindowLockpicksCount:SetText(ChestFarmer.numLockpicks .. " lockpicks remaining")
@@ -573,6 +564,7 @@ end
 
 EVENT_MANAGER:RegisterForEvent(ChestFarmer.name, EVENT_ADD_ON_LOADED, ChestFarmer.onAddonLoaded)
 EVENT_MANAGER:RegisterForEvent(ChestFarmer.name, EVENT_PLAYER_ACTIVATED, ChestFarmer.cfRead)
+EVENT_MANAGER:RegisterForEvent(ChestFarmer.name, EVENT_BEGIN_LOCKPICK, ChestFarmer.saveQuality)
 EVENT_MANAGER:RegisterForEvent(ChestFarmer.name, EVENT_LOCKPICK_SUCCESS, ChestFarmer.countIncrement)
 EVENT_MANAGER:RegisterForEvent(ChestFarmer.name, EVENT_ITEM_SET_COLLECTION_UPDATED,	ChestFarmer.cfRead)
 EVENT_MANAGER:RegisterForUpdate("fixCollected", 3000, ChestFarmer.fixCollected)

--- a/ChestFarmer/ChestFarmer.txt
+++ b/ChestFarmer/ChestFarmer.txt
@@ -33,7 +33,7 @@ ChestFarmer.lua
 ChestFarmer.xml
 
 ; Changelog:
-; v1.13
+; v1.13 (19.05.2021)
 ; * Added support for tracking chest quality. Now use slash command 
 ;   "/cf stats" or press the GUI button to see total chests opened,
 ;   quality % across Master, Advanced, Intermediate, and Simple.

--- a/ChestFarmer/ChestFarmer.txt
+++ b/ChestFarmer/ChestFarmer.txt
@@ -31,3 +31,34 @@
 
 ChestFarmer.lua
 ChestFarmer.xml
+
+; Changelog:
+; v1.13
+; * Added support for tracking chest quality. Now use slash command 
+;   "/cf stats" or press the GUI button to see total chests opened,
+;   quality % across Master, Advanced, Intermediate, and Simple.
+;   For users updating from v1.12 and below, the sample size will be different from 
+;   your total chest count. I didn't want to affect your zone chest counts saved in 
+;   savedVars, so if you want truly accurate tracking I recommend reinstalling the addon
+; * Added slash-commands
+;   * "/cf" -> Toggles ChestFarmer GUI
+;   * "/cf reset" -> reset current zone's chest count
+;   * "/cf stats" -> Historical stats, see above
+; * Changed edge-case definitions and set-up ChestFarmer.Default for initial
+;   set-up savedVars.
+;
+; v1.12 (28.04.2021)
+; * Minor bugfix to savedVars definition to work as intended across servers 
+;   (thanks Baertram). Unfortunately your old chest count will be reset. 
+;   To migrate old chest count run the addon once, then go to 
+;   ../Documents/Elder Scrolls Online/live/SavedVariables/ChestFarmer.lua
+;   and copy-paste old values to the new table.
+;
+; v1.11
+; * Minor bugfix
+;
+; v1.1
+; * Added support for Blackwood zone, delves and public dungeon
+;
+; v1.0 (23.04.2021)
+; * First release

--- a/ChestFarmer/ChestFarmer.txt
+++ b/ChestFarmer/ChestFarmer.txt
@@ -1,5 +1,5 @@
 ## Title: |cffd700ChestFarmer|r
-## Description: Use command '/chestfarmer' to toggle GUI. Counts chests lockpicked in each zone. Optional GUI that also displays lockpicks remaining and overland set collection %.
+## Description: Use command '/chestfarmer' or '/cf' to toggle GUI. Counts chests lockpicked in each zone and tracks quality. Optional GUI that also displays lockpicks remaining and overland set collection %.
 ## Author: @xgoku1
 ## Version: 1
 ## APIVersion: 100034 100035

--- a/ChestFarmer/ChestFarmer.xml
+++ b/ChestFarmer/ChestFarmer.xml
@@ -21,7 +21,7 @@
 				</Label>
 				
 				<Button name="$(parent)Collections" text="Open Set Collections">
-					<Anchor point="CENTER" relativeTo="$(parent)Title" relativePoint="CENTER" offsetY="30" offsetX="0"/>
+					<Anchor point="CENTER" relativeTo="$(parent)Title" relativePoint="CENTER" offsetY="30" offsetX="-20"/>
 					<Textures 
 						normal = "EsoUI/Art/Collections/collections_tabIcon_itemSets_up.dds"
 						pressed = "EsoUI/Art/Collections/collections_tabIcon_itemSets_down.dds"
@@ -33,7 +33,7 @@
 				</Button>
 				
 				<Button name="$(parent)CloseButton">
-					<Anchor point="CENTER" relativeTo="$(parent)Collections" relativePoint="CENTER" offsetY="1" offsetX="-50"/>
+					<Anchor point="CENTER" relativeTo="$(parent)Collections" relativePoint="CENTER" offsetY="1" offsetX="-25"/>
 					<Textures
 					normal="esoui/art/tutorial/tabicon_ignored_up.dds"
 					pressed="esoui/art/contacts/tabicon_ignored_down.dds"
@@ -45,7 +45,7 @@
 				</Button>
 				
 				<Button name="$(parent)ChestsReset">
-					<Anchor point="CENTER" relativeTo="$(parent)Collections" relativePoint="CENTER" offsetY="1" offsetX="50"/>
+					<Anchor point="CENTER" relativeTo="$(parent)Collections" relativePoint="CENTER" offsetY="1" offsetX="25"/>
 					<Textures 
 						normal		="esoui/art/help/help_tabicon_feedback_up.dds"
 						pressed		="esoui/art/help/help_tabicon_feedback_down.dds "
@@ -53,6 +53,18 @@
 					<Dimensions x="35" y="35" />
 					<OnClicked>	ChestFarmer.resetButtonPressed() </OnClicked>
 					<OnMouseEnter>ChestFarmer.chestsReset_showTooltip(self)</OnMouseEnter>
+					<OnMouseExit>ChestFarmer.hideTooltip(self)</OnMouseExit>
+				</Button>
+				
+				<Button name="$(parent)ShowStats">
+					<Anchor point="CENTER" relativeTo="$(parent)Collections" relativePoint="CENTER" offsetY="1" offsetX="50"/>
+					<Textures 
+						normal		="esoui/art/help/help_tabicon_feedback_up.dds"
+						pressed		="esoui/art/help/help_tabicon_feedback_down.dds "
+						mouseOver	="esoui/art/help/help_tabicon_feedback_over.dds"/>
+					<Dimensions x="35" y="35" />
+					<OnClicked>	ChestFarmer.statsButtonPressed() </OnClicked>
+					<OnMouseEnter>ChestFarmer.showStats_showTooltip(self)</OnMouseEnter>
 					<OnMouseExit>ChestFarmer.hideTooltip(self)</OnMouseExit>
 				</Button>
 				

--- a/ChestFarmer/ChestFarmer.xml
+++ b/ChestFarmer/ChestFarmer.xml
@@ -21,7 +21,7 @@
 				</Label>
 				
 				<Button name="$(parent)Collections" text="Open Set Collections">
-					<Anchor point="CENTER" relativeTo="$(parent)Title" relativePoint="CENTER" offsetY="30" offsetX="-20"/>
+					<Anchor point="CENTER" relativeTo="$(parent)Title" relativePoint="CENTER" offsetY="30" offsetX="-25"/>
 					<Textures 
 						normal = "EsoUI/Art/Collections/collections_tabIcon_itemSets_up.dds"
 						pressed = "EsoUI/Art/Collections/collections_tabIcon_itemSets_down.dds"
@@ -33,7 +33,7 @@
 				</Button>
 				
 				<Button name="$(parent)CloseButton">
-					<Anchor point="CENTER" relativeTo="$(parent)Collections" relativePoint="CENTER" offsetY="1" offsetX="-25"/>
+					<Anchor point="CENTER" relativeTo="$(parent)Collections" relativePoint="CENTER" offsetY="1" offsetX="-55"/>
 					<Textures
 					normal="esoui/art/tutorial/tabicon_ignored_up.dds"
 					pressed="esoui/art/contacts/tabicon_ignored_down.dds"
@@ -45,7 +45,7 @@
 				</Button>
 				
 				<Button name="$(parent)ChestsReset">
-					<Anchor point="CENTER" relativeTo="$(parent)Collections" relativePoint="CENTER" offsetY="1" offsetX="25"/>
+					<Anchor point="CENTER" relativeTo="$(parent)Collections" relativePoint="CENTER" offsetY="0" offsetX="55"/>
 					<Textures 
 						normal		="esoui/art/help/help_tabicon_feedback_up.dds"
 						pressed		="esoui/art/help/help_tabicon_feedback_down.dds "
@@ -57,11 +57,11 @@
 				</Button>
 				
 				<Button name="$(parent)ShowStats">
-					<Anchor point="CENTER" relativeTo="$(parent)Collections" relativePoint="CENTER" offsetY="1" offsetX="50"/>
+					<Anchor point="CENTER" relativeTo="$(parent)ChestsReset" relativePoint="CENTER" offsetY="1" offsetX="52"/>
 					<Textures 
-						normal		="esoui/art/help/help_tabicon_feedback_up.dds"
-						pressed		="esoui/art/help/help_tabicon_feedback_down.dds "
-						mouseOver	="esoui/art/help/help_tabicon_feedback_over.dds"/>
+						normal		="/esoui/art/icons/achievements_indexicon_summary_up.dds"
+						pressed		="/esoui/art/icons/achievements_indexicon_summary_down.dds"
+						mouseOver	="/esoui/art/icons/achievements_indexicon_summary_over.dds"/>
 					<Dimensions x="35" y="35" />
 					<OnClicked>	ChestFarmer.statsButtonPressed() </OnClicked>
 					<OnMouseEnter>ChestFarmer.showStats_showTooltip(self)</OnMouseEnter>
@@ -69,7 +69,7 @@
 				</Button>
 				
 				<Label name="$(parent)ZoneDisplay" width="30" height="10" font="ZoFontWinH3" inheritAlpha="true" color="FFFFCC" wrapMode="TRUNCATE" verticalAlignment="TOP" horizontalAlignment="LEFT" text="Current zone">
-					<Anchor point="TOP" relativeTo="$(parent)Collections" relativePoint="CENTER" offsetY="20" offsetX="0"/>
+					<Anchor point="TOP" relativeTo="$(parent)Title" relativePoint="CENTER" offsetY="50" offsetX="0"/>
 				</Label>
 
 				<Label name="$(parent)LockpicksCount" width="30" height="10" font="ZoFontWinH3" inheritAlpha="true" color="FFFFCC" wrapMode="TRUNCATE" verticalAlignment="TOP" horizontalAlignment="LEFT" text="Lockpicks remaining: ">

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Addon for Elder Scrolls Online; helps track farming overland chests for profit a
 **Features**
 - - - -
 - Accountwide count of treasure-chests opened per zone
+
+- Chest quality tracking
      
 - Lockpicks remaining count
 


### PR DESCRIPTION
- Adds chest quality tracking
  - Print total chests opened and quality stats to chat using a GUI button or /cf stats slash-command
- Added Default definition for savedVars
- Updated slash-commands to include short-hand "/cf" as a valid slash command alongside "/chestfarmer"
- Changed default position of GUI for initial load to bottom-right
![CF v113 buttons](https://user-images.githubusercontent.com/25822369/118774792-d5bc4e80-b8a3-11eb-832c-18c8e2785b57.png)
![CF v113 Screen2](https://user-images.githubusercontent.com/25822369/118774830-dead2000-b8a3-11eb-8294-e3db505bd6c3.png)

