### PR TITLE
Auto-open Mirri boxes

### DIFF
--- a/ChestFarmer/ChestFarmer.lua
+++ b/ChestFarmer/ChestFarmer.lua
@@ -100,9 +100,16 @@ function ChestFarmer.SetScene()
 	end
 end
 
-function ChestFarmer.hookCheck()
-	local lootInfo = {GetLootTargetInfo()}
-	if	(lootInfo[1]=="Hidden Treasure Bag") and (running==true) then return true
+function ChestFarmer.hookCheck(loot, name, actionName, isOwned)
+	local itemIds = {
+		178470 -- id for Hidden Treasure Bag
+	}
+	local itemNames = {}
+	for _,itemId in ipairs(itemIds) do
+		itemNames[zo_strformat(SI_TOOLTIP_ITEM_NAME, GetItemLinkName(string.format("|H1:item:%d:0:0:0:0:0:0:0:0:0:0:0:0:0:1:0:0:1:0:0:0|h|h", itemId)))] = true
+	end
+	
+	if (itemNames[name] == true) and (running == true) then return true
 	else return false
 	end
 end

--- a/ChestFarmer/ChestFarmer.lua
+++ b/ChestFarmer/ChestFarmer.lua
@@ -88,6 +88,7 @@ end
 function ChestFarmer.Initialize()
 	ChestFarmer.savedVariables = ZO_SavedVars:NewAccountWide("ChestFarmerSavedData", 1, nil, ChestFarmer.Default, GetWorldName())	
 	ChestFarmer.RestorePosition()
+	ZO_PreHook(SYSTEMS:GetObject("loot"), "UpdateLootWindow", ChestFarmer.hookCheck)
 end
 
 function ChestFarmer.SetScene()
@@ -96,6 +97,13 @@ function ChestFarmer.SetScene()
 	if ChestFarmer.savedVariables.guiHidden == false then
 		HUD_SCENE:AddFragment(fragment)
 		HUD_UI_SCENE:AddFragment(fragment)
+	end
+end
+
+function ChestFarmer.hookCheck()
+	local lootInfo = {GetLootTargetInfo()}
+	if	(lootInfo[1]=="Hidden Treasure Bag") and (running==true) then return true
+	else return false
 	end
 end
 
@@ -118,12 +126,13 @@ function ChestFarmer.lootContainer()
 		lastScene = "hudui"
 	end
 	LootAll()
+	running = false
 	EVENT_MANAGER:UnregisterForEvent(ChestFarmer.name, EVENT_LOOT_UPDATED)
 end
 
 function ChestFarmer.OpenABox(bag, slot)
+	running = true
 	EVENT_MANAGER:RegisterForEvent(ChestFarmer.name, EVENT_LOOT_UPDATED, ChestFarmer.lootContainer)
-	
 	EVENT_MANAGER:UnregisterForUpdate("openBoxRecursive")
 	
 	if IsProtectedFunction("UseItem") then
@@ -136,6 +145,7 @@ function ChestFarmer.OpenABox(bag, slot)
 end
 
 function ChestFarmer.OpenContainers()
+	
 	EVENT_MANAGER:UnregisterForUpdate("openContainersRecursive")
 	local inventoryCount = GetBagSize(INVENTORY_BACKPACK)
 	for x = 0, inventoryCount do

--- a/ChestFarmer/ChestFarmer.txt
+++ b/ChestFarmer/ChestFarmer.txt
@@ -3,6 +3,7 @@
 ## Author: @xgoku1
 ## Version: 1
 ## APIVersion: 101031 101032
+## OptionalDependsOn: LibCustomMenu>=692
 ## SavedVariables: ChestFarmerSavedData
 
 # This Add-on is not created by, affiliated with, or sponsored by, ZeniMax Media Inc.


### PR DESCRIPTION
- Added auto-open Mirri boxes feature
- Optional dependency on LibCustomMenu
- Iterates over inventory, finds Mirri boxes and open them
- Language independent logic to hide loot screen while opening the boxes
- Tested with multiple boxes, different client language
- Edge-cases: Auto-open won't work if free inventory space <4 or if character is in combat/dead
- Thanks to Baertram, silvereyes, Dolgubon, and Zelenin for help with code